### PR TITLE
Apply uprating before reforms

### DIFF
--- a/openfisca_tools/microsimulation.py
+++ b/openfisca_tools/microsimulation.py
@@ -98,9 +98,9 @@ class Microsimulation:
         self.apply_reform(
             (
                 self.pre_reform,
+                carry_over_by_default,
                 self.reform,
                 self.post_reform,
-                carry_over_by_default,
             )
         )
         builder = SimulationBuilder()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-Tools",
-    version="0.1.6",
+    version="0.1.7",
     author="PolicyEngine",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/openfisca-tools",


### PR DESCRIPTION
This caused a bug where if a variable is uprated, the uprating formula overrides any abolition reforms.