### PR TITLE
Bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-Tools",
-    version="0.4.1",
+    version="0.5.0",
     author="PolicyEngine",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/openfisca-tools",


### PR DESCRIPTION
#33 did not correctly update the version number, causing the PyPI deployment to fail (the changelog was updated correctly). Bumping up to 0.5.0.