### PR TITLE
Combine entities into required groups automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2022-04-18
+
+### Fixed
+
+* Group entities are now created automatically in `IndividualSim`s.
+
 ## [0.9.0] - 2022-04-11
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-Tools",
-    version="0.9.0",
+    version="0.9.1",
     author="PolicyEngine",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/openfisca-tools",


### PR DESCRIPTION
Fixes #46 (by making it redundant)
Fixes #25 

Essentially, country packages should specify the required group entities, and the default roles that should be assigned when grouping "orphan" entities into groups. For OpenFisca-US, this looks like:

```python
class IndividualSim(GeneralIndividualSim):
    tax_benefit_system = CountryTaxBenefitSystem
    entities = {entity.key: entity for entity in entities}
    default_dataset = CPS

    # New code below
    required_entities = ["household", "spm_unit", "family", "tax_unit"]
    default_roles = {
        "household": "member",
        "spm_unit": "member",
        "family": "member",
        "tax_unit": "member",
    }
```