### PR TITLE
Add mapping logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2022-04-24
+
+### Fixed
+
+* `map_to` is correctly used in `deriv` calls.
+
 ## [0.10.0] - 2022-04-18
 
 ### Fixed

--- a/openfisca_tools/hypothetical.py
+++ b/openfisca_tools/hypothetical.py
@@ -258,7 +258,7 @@ class IndividualSim:
 
         if self.parametric_vary and reform is None:
             results = [
-                self.calc(var, period, target, index, reform)
+                self.calc(var, period=period, target=target, index=index, map_to=map_to, reform=reform)
                 for reform in self.parametric_reforms
             ]
             return np.array(results)

--- a/openfisca_tools/hypothetical.py
+++ b/openfisca_tools/hypothetical.py
@@ -258,7 +258,14 @@ class IndividualSim:
 
         if self.parametric_vary and reform is None:
             results = [
-                self.calc(var, period=period, target=target, index=index, map_to=map_to, reform=reform)
+                self.calc(
+                    var,
+                    period=period,
+                    target=target,
+                    index=index,
+                    map_to=map_to,
+                    reform=reform,
+                )
                 for reform in self.parametric_reforms
             ]
             return np.array(results)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-Tools",
-    version="0.9.1",
+    version="0.10.1",
     author="PolicyEngine",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/openfisca-tools",


### PR DESCRIPTION
This ensures ``IndividualSim.deriv` always operates on the given entities correctly.

When using `deriv` where `wrt` and `target` have different entities, you'll need to specify a target entity for at least the `wrt` variable. For example:

```python
sim = IndividualSim(year=2022)
sim.add_person(name="adult", age=30, employment_income=250 * 12)
sim.add_person(name="child", age=10)
sim.add_spm_unit(
    name="spm_unit", members=["adult", "child"], is_tanf_enrolled=enrolled
)
sim.add_household(
    name="household", members=["adult", "child"], state_code=state_code
)

sim.vary("employment_income", max=1000 * 12, step=120)

sim.deriv("tanf", "employment_income", wrt_target="adult") # <- I've added "adult". I could've instead added "spm_unit".
```