### PR TITLE
Add partially-executed formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2022-07-19
+
+### Added
+
+* `defined_for: str`: a `Variable` property that calculates the formula only where the variable `defined_for` is `True`.
+
 ## [0.12.0] - 2022-06-22
 
 ### Fixed

--- a/openfisca_tools/model_api/defined_for.py
+++ b/openfisca_tools/model_api/defined_for.py
@@ -5,6 +5,14 @@ from openfisca_core.variables import Variable
 from numpy.typing import ArrayLike
 from typing import Any, Callable
 
+class PopulationSubset:
+    def __init__(self, population: Population, mask: ArrayLike):
+        self.population = population
+        self.mask = mask
+
+    def __call__(self, variable, period):
+        return self.population(variable, period)[self.mask]
+
 
 def make_partially_executed_formula(
     formula: Callable, mask: ArrayLike, default_value: Any = 0
@@ -20,14 +28,13 @@ def make_partially_executed_formula(
         else:
             mask_values = mask
 
-        def entity_call(self, variable, period):
-            full_result = Variable(entity, period, parameters)
-            return full_result[mask_values]
+        entity = PopulationSubset(entity, mask_values)
 
-        setattr(entity, "__call__", entity_call)
+        formula_result = formula(entity, period, parameters)
+        result = np.ones_like(mask_values, dtype=formula_result.dtype) * default_value
+        result[mask_values] = formula_result
 
-        result = np.full(mask_values.shape, default_value)
-        result[mask_values] = formula(entity, period, parameters)
+        entity = entity.population
 
         return result
     

--- a/openfisca_tools/model_api/defined_for.py
+++ b/openfisca_tools/model_api/defined_for.py
@@ -16,15 +16,19 @@ def make_partially_executed_formula(
 
     def partially_executed_formula(entity, period, parameters):
         if isinstance(mask, str):
-            mask = entity(mask, period)
+            mask_values = entity(mask, period)
+        else:
+            mask_values = mask
 
         def entity_call(self, variable, period):
             full_result = Variable(entity, period, parameters)
-            return full_result[mask]
+            return full_result[mask_values]
 
         setattr(entity, "__call__", entity_call)
 
-        result = np.full(mask.shape, default_value)
-        result[mask] = formula(entity, period, parameters)
+        result = np.full(mask_values.shape, default_value)
+        result[mask_values] = formula(entity, period, parameters)
 
         return result
+    
+    return partially_executed_formula

--- a/openfisca_tools/model_api/defined_for.py
+++ b/openfisca_tools/model_api/defined_for.py
@@ -1,0 +1,30 @@
+import numpy as np
+from openfisca_core.entities import Entity
+from openfisca_core.populations import Population, GroupPopulation
+from openfisca_core.variables import Variable
+from numpy.typing import ArrayLike
+from typing import Any, Callable
+
+
+def make_partially_executed_formula(
+    formula: Callable, mask: ArrayLike, default_value: Any = 0
+) -> Callable:
+    # Edge cases that need to be covered:
+    # * entity(variable, period)
+    # * entity.members(variable, period)
+    # * entity.parent_entity(variable, period)
+
+    def partially_executed_formula(entity, period, parameters):
+        if isinstance(mask, str):
+            mask = entity(mask, period)
+
+        def entity_call(self, variable, period):
+            full_result = Variable(entity, period, parameters)
+            return full_result[mask]
+
+        setattr(entity, "__call__", entity_call)
+
+        result = np.full(mask.shape, default_value)
+        result[mask] = formula(entity, period, parameters)
+
+        return result

--- a/openfisca_tools/model_api/defined_for.py
+++ b/openfisca_tools/model_api/defined_for.py
@@ -64,6 +64,7 @@ def make_partially_executed_formula(
         subset_entity = PopulationSubset(entity, mask_values)
 
         formula_result = formula(subset_entity, period, parameters)
+        formula_result = np.array(formula_result)
         result = (
             np.ones_like(mask_values, dtype=formula_result.dtype)
             * default_value

--- a/openfisca_tools/model_api/model_api.py
+++ b/openfisca_tools/model_api/model_api.py
@@ -49,6 +49,11 @@ class Variable(CoreVariable):
         self.is_neutralized = False
 
         if hasattr(self, "defined_for"):
+            if not isinstance(self.defined_for, str):
+                if hasattr(self.defined_for, "value"):
+                    self.defined_for = self.defined_for.value
+                else:
+                    self.defined_for = str(self.defined_for)
             for formula_key, formula in self.formulas.items():
                 formula = make_partially_executed_formula(
                     formula, self.defined_for

--- a/openfisca_tools/model_api/model_api.py
+++ b/openfisca_tools/model_api/model_api.py
@@ -19,9 +19,13 @@ from numpy.typing import ArrayLike
 from pandas import Period
 from itertools import product
 
+from openfisca_tools.model_api.defined_for import (
+    make_partially_executed_formula,
+)
+
 ReformType = Union[Reform, Tuple[Reform]]
 
-allowed_variable_attributes = ("metadata", "quantity_type")
+allowed_variable_attributes = ("metadata", "quantity_type", "defined_for")
 
 STOCK = "Stock"
 FLOW = "Flow"
@@ -43,6 +47,13 @@ class Variable(CoreVariable):
                 raise e
 
         self.is_neutralized = False
+
+        if hasattr(self, "defined_for"):
+            for formula_key, formula in self.formulas.items():
+                formula = make_partially_executed_formula(
+                    formula, self.defined_for
+                )
+                self.formulas[formula_key] = formula
 
 
 np.random.seed(0)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-Tools",
-    version="0.12.0",
+    version="0.13.0",
     author="PolicyEngine",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/openfisca-tools",

--- a/tests/test_model_api/test_defined_for/test_defined_for.py
+++ b/tests/test_model_api/test_defined_for/test_defined_for.py
@@ -70,9 +70,10 @@ def test_defined_for_with_deps():
         defined_for = "in_england"
 
         def formula(person, period, parameters):
-            return 1 - person("tax", period)
+            tax = person("tax", period)
+            return 1 - tax
     
-    system.add_variables(in_england, income)
+    system.add_variables(in_england, income, tax)
 
     simulation = SimulationBuilder().build_from_dict(system, {
         "people": {

--- a/tests/test_model_api/test_defined_for/test_defined_for.py
+++ b/tests/test_model_api/test_defined_for/test_defined_for.py
@@ -4,9 +4,9 @@ from openfisca_core.taxbenefitsystems import TaxBenefitSystem
 from openfisca_tools.model_api import *
 from openfisca_core.entities import Entity
 
+
 def test_defined_for_no_deps():
-    """A basic test of the defined-for logic, on a variable with no dependencies.
-    """
+    """A basic test of the defined-for logic, on a variable with no dependencies."""
     Person = Entity("person", "people", "Person", "A person")
     system = TaxBenefitSystem([Person])
 
@@ -25,25 +25,28 @@ def test_defined_for_no_deps():
 
         def formula(person, period, parameters):
             return 1
-    
+
     system.add_variables(in_england, income)
 
-    simulation = SimulationBuilder().build_from_dict(system, {
-        "people": {
-            "first_person": {
-                "in_england": {2022: True},
-            },
-            "second_person": {
-                "in_england": {2022: False},
+    simulation = SimulationBuilder().build_from_dict(
+        system,
+        {
+            "people": {
+                "first_person": {
+                    "in_england": {2022: True},
+                },
+                "second_person": {
+                    "in_england": {2022: False},
+                },
             },
         },
-    })
+    )
 
     assert all(simulation.calculate("income", 2022) == np.array([1, 0]))
 
+
 def test_defined_for_with_deps():
-    """An intermediate test of the defined-for logic, on a variable with one dependent variable.
-    """
+    """An intermediate test of the defined-for logic, on a variable with one dependent variable."""
     Person = Entity("person", "people", "Person", "A person")
     system = TaxBenefitSystem([Person])
 
@@ -72,20 +75,24 @@ def test_defined_for_with_deps():
         def formula(person, period, parameters):
             tax = person("tax", period)
             return 1 - tax
-    
+
     system.add_variables(in_england, income, tax)
 
-    simulation = SimulationBuilder().build_from_dict(system, {
-        "people": {
-            "first_person": {
-                "in_england": {2022: True},
-            },
-            "second_person": {
-                "in_england": {2022: False},
+    simulation = SimulationBuilder().build_from_dict(
+        system,
+        {
+            "people": {
+                "first_person": {
+                    "in_england": {2022: True},
+                },
+                "second_person": {
+                    "in_england": {2022: False},
+                },
             },
         },
-    })
+    )
 
     assert all(simulation.calculate("income", 2022) == np.array([0.5, 0]))
+
 
 test_defined_for_with_deps()

--- a/tests/test_model_api/test_defined_for/test_defined_for.py
+++ b/tests/test_model_api/test_defined_for/test_defined_for.py
@@ -1,0 +1,90 @@
+import numpy as np
+from openfisca_core.simulation_builder import SimulationBuilder
+from openfisca_core.taxbenefitsystems import TaxBenefitSystem
+from openfisca_tools.model_api import *
+from openfisca_core.entities import Entity
+
+def test_defined_for_no_deps():
+    """A basic test of the defined-for logic, on a variable with no dependencies.
+    """
+    Person = Entity("person", "people", "Person", "A person")
+    system = TaxBenefitSystem([Person])
+
+    class in_england(Variable):
+        value_type = bool
+        entity = Person
+        definition_period = ETERNITY
+        label = "In England"
+
+    class income(Variable):
+        value_type = float
+        entity = Person
+        definition_period = ETERNITY
+        label = "Income"
+        defined_for = "in_england"
+
+        def formula(person, period, parameters):
+            return 1
+    
+    system.add_variables(in_england, income)
+
+    simulation = SimulationBuilder().build_from_dict(system, {
+        "people": {
+            "first_person": {
+                "in_england": {2022: True},
+            },
+            "second_person": {
+                "in_england": {2022: False},
+            },
+        },
+    })
+
+    assert all(simulation.calculate("income", 2022) == np.array([1, 0]))
+
+def test_defined_for_with_deps():
+    """An intermediate test of the defined-for logic, on a variable with one dependent variable.
+    """
+    Person = Entity("person", "people", "Person", "A person")
+    system = TaxBenefitSystem([Person])
+
+    class in_england(Variable):
+        value_type = bool
+        entity = Person
+        definition_period = ETERNITY
+        label = "In England"
+
+    class tax(Variable):
+        value_type = float
+        entity = Person
+        definition_period = ETERNITY
+        label = "Tax"
+
+        def formula(person, period, parameters):
+            return 0.5
+
+    class income(Variable):
+        value_type = float
+        entity = Person
+        definition_period = ETERNITY
+        label = "Income"
+        defined_for = "in_england"
+
+        def formula(person, period, parameters):
+            return 1 - person("tax", period)
+    
+    system.add_variables(in_england, income)
+
+    simulation = SimulationBuilder().build_from_dict(system, {
+        "people": {
+            "first_person": {
+                "in_england": {2022: True},
+            },
+            "second_person": {
+                "in_england": {2022: False},
+            },
+        },
+    })
+
+    assert all(simulation.calculate("income", 2022) == np.array([0.5, 0]))
+
+test_defined_for_with_deps()


### PR DESCRIPTION
cc @MaxGhenis 

The tricky bit here is covering all the edge cases cleanly, and at the last possible point. We need to ensure that the following all return their subsetted versions:
* `entity(variable, period)`
* `entity.members(variable, period)`
* `entity.parent_entity(variable, period`
* `entity.sum(...)` and all other group functions