### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,14 +16,14 @@ jobs:
           options: ". -l 79 --check"
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.7"
       - name: Install dependencies
         run: make install
       - name: Run the main tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,8 +7,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: psf/black@stable
         with:
           options: ". -l 79 --check"
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.7
       - name: Install dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - uses: psf/black@stable
         with:
           options: ". -l 79 --check"
@@ -21,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - name: Install dependencies
         run: make install
       - name: Run the main tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,14 +19,14 @@ jobs:
           options: ". -l 79 --check"
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.7"
       - name: Install dependencies
         run: make install
       - name: Run the main tests
@@ -34,14 +34,14 @@ jobs:
   publish:
     name: Deploy
     if: github.repository == 'PolicyEngine/openfisca-tools'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.7"
       - name: Publish a git tag
         run: ".github/publish-git-tag.sh"
       - name: Install dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - uses: psf/black@stable
         with:
           options: ". -l 79 --check"
@@ -24,7 +26,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - name: Install dependencies
         run: make install
       - name: Run the main tests
@@ -39,7 +41,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - name: Publish a git tag
         run: ".github/publish-git-tag.sh"
       - name: Install dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,8 +10,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: psf/black@stable
         with:
           options: ". -l 79 --check"
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.7
       - name: Install dependencies
@@ -35,9 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.7
       - name: Publish a git tag

--- a/openfisca_tools/hypothetical.py
+++ b/openfisca_tools/hypothetical.py
@@ -1,6 +1,7 @@
 """
 IndividualSim and any other interfaces to intialising and running simulations on hypothetical situations.
 """
+
 from typing import Dict, List
 from openfisca_core.entities.entity import Entity
 from openfisca_tools.model_api.model_api import ReformType

--- a/openfisca_tools/microsimulation.py
+++ b/openfisca_tools/microsimulation.py
@@ -1,6 +1,7 @@
 """
 Microsimulation interfaces and utility functions.
 """
+
 import logging
 from re import S
 from typing import Callable, List, Tuple

--- a/openfisca_tools/reforms.py
+++ b/openfisca_tools/reforms.py
@@ -1,6 +1,7 @@
 """
 Utility functions for writing reforms.
 """
+
 from pathlib import Path
 from typing import Type
 from openfisca_core.parameters.helpers import load_parameter_file

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ setup(
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/openfisca-tools",
     install_requires=[
-        "OpenFisca-Core>=42,<43",
+        "OpenFisca-Core>=38,<39",
         "microdf_python",
-        "numpy",
+        "numpy<1.21",
         "pandas",
         "wheel",
         "h5py",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/openfisca-tools",
     install_requires=[
-        "OpenFisca-Core<44",
+        "OpenFisca-Core>=43,<44",
         "microdf_python",
         "numpy",
         "pandas",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/openfisca-tools",
     install_requires=[
-        "OpenFisca-Core",
+        "OpenFisca-Core<44",
         "microdf_python",
         "numpy",
         "pandas",

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     install_requires=[
         "OpenFisca-Core>=38,<39",
         "microdf_python",
+        "matplotlib<4",
         "numpy<1.21",
         "pandas",
         "wheel",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url="https://github.com/policyengine/openfisca-tools",
     install_requires=[
-        "OpenFisca-Core>=43,<44",
+        "OpenFisca-Core>=42,<43",
         "microdf_python",
         "numpy",
         "pandas",


### PR DESCRIPTION
Updates GitHub Actions workflow action versions to releases that run on Node.js 24, removing Node.js 20 JavaScript action deprecation warnings before GitHub-hosted runners switch defaults on June 2, 2026.

This is a mechanical workflow-only change from an org-wide scan. It also updates older checkout/setup/action versions that still advertised Node.js 12 or 16 runtimes where a Node.js 24 successor is available.